### PR TITLE
when running on cli have unlimited exec time

### DIFF
--- a/cssmin.php
+++ b/cssmin.php
@@ -44,7 +44,11 @@ class CSSmin
     {
         // Set suggested PHP limits
         $this->memory_limit = 128 * 1048576; // 128MB in bytes
-        $this->max_execution_time = 60; // 1 min
+        if (php_sapi_name() != "cli") {
+            $this->max_execution_time = 60; // 1 min
+        } else {
+            $this->max_execution_time = 0; // unlimited
+        }
         $this->pcre_backtrack_limit = 1000 * 1000;
         $this->pcre_recursion_limit =  500 * 1000;
 


### PR DESCRIPTION
When we are running on cli we should not tamper with the
max_execution_time and just 'leave' it to 0 (unlimited)

Signed-off-by: BlackEagle <ike.devolder@gmail.com>